### PR TITLE
Fix the lint command. Currently failing with 'Cannot find...

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "yaml": "^2.6.1"
   },
   "devDependencies": {
+    "@eslint/js": "^9.17.0",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
     "@types/inquirer": "^9.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
         specifier: ^2.6.1
         version: 2.8.2
     devDependencies:
+      '@eslint/js':
+        specifier: ^9.17.0
+        version: 9.39.2
       '@semantic-release/changelog':
         specifier: ^6.0.3
         version: 6.0.3(semantic-release@24.2.9(typescript@5.9.3))


### PR DESCRIPTION
## Summary
- Add missing `@eslint/js` dependency to fix failing lint command
- ESLint 9's flat config format requires `@eslint/js` as an explicit dependency (no longer bundled with `eslint`)

## Test Plan
- [ ] Run `pnpm install` to install the new dependency
- [ ] Run `pnpm run lint` - should execute without "Cannot find package '@eslint/js'" error
- [ ] Run `pnpm run lint:fix` - should work correctly

Closes #1
