### PR TITLE
When creating a ticket, there is an ai comment before the...

### DIFF
--- a/progress.txt
+++ b/progress.txt
@@ -14,3 +14,8 @@ Each entry documents: date, feature, decisions, files changed, tests, and concer
 - Files: src/commands/create.ts
 - Changes: Replaced logger.box() bordered table with clean section-based format using chalk styling. Labels displayed inline, body content shown with indentation for readability.
 - Decisions: Used bold cyan headers for sections, removed 500-char truncation to show full body content for better review.
+
+[2026-01-10] #10 fix: strip AI preamble from generated ticket bodies
+- Files: src/lib/claude.ts, src/lib/claude.test.ts
+- Changes: Added explicit instruction in prompt to start with "## Description" without preamble. Updated extractIssueBody to strip any text before "## Description" as safety measure.
+- Decisions: Two-layer defense: prompt instruction + extraction cleanup.

--- a/src/lib/claude.test.ts
+++ b/src/lib/claude.test.ts
@@ -81,4 +81,42 @@ describe("extractIssueBody", () => {
     const body = extractIssueBody(output);
     expect(body).toBe("Line 1\nLine 2\nLine 3");
   });
+
+  it("should strip preamble text before ## Description", () => {
+    const output = "Here's a GitHub issue for you:\n\n## Description\nActual content";
+    const body = extractIssueBody(output);
+    expect(body).toBe("## Description\nActual content");
+  });
+
+  it("should strip preamble and META line together", () => {
+    const output = "I'll create this issue:\n\n## Description\nContent here\nMETA:type=feature,priority=high,risk=low,area=ui";
+    const body = extractIssueBody(output);
+    expect(body).toBe("## Description\nContent here");
+  });
+
+  it("should handle output starting with ## Description (no preamble)", () => {
+    const output = "## Description\nContent here\nMETA:type=feature,priority=high,risk=low,area=ui";
+    const body = extractIssueBody(output);
+    expect(body).toBe("## Description\nContent here");
+  });
+
+  it("should preserve full issue body after stripping preamble", () => {
+    const output = `Sure, here's the issue:
+
+## Description
+Add dark mode support
+
+## Technical Context
+**Type:** feature
+
+## Implementation Steps
+- [ ] Step 1
+META:type=feature,priority=high,risk=low,area=ui`;
+    const body = extractIssueBody(output);
+    expect(body).toContain("## Description");
+    expect(body).toContain("## Technical Context");
+    expect(body).toContain("## Implementation Steps");
+    expect(body).not.toContain("Sure, here's the issue");
+    expect(body).not.toContain("META:");
+  });
 });

--- a/src/lib/claude.ts
+++ b/src/lib/claude.ts
@@ -82,7 +82,9 @@ User Request: ${description}
 
 ${agentInstructions ? `Project-Specific Instructions:\n${agentInstructions}\n\n` : ""}${additionalHints ? `Additional Context/Hints:\n${additionalHints}\n\n` : ""}
 
-Create a detailed GitHub issue following this exact template:
+Create a detailed GitHub issue following this exact template.
+
+IMPORTANT: Start your output IMMEDIATELY with "## Description" - do not include any preamble, commentary, or introduction before the template.
 
 ## Description
 [Clear user-facing description of what needs to be done]
@@ -207,5 +209,13 @@ export function parseTicketMeta(
 
 export function extractIssueBody(output: string): string {
   // Remove the META line from the output
-  return output.replace(/\n?META:type=\w+,priority=\w+,risk=\w+,area=\w+\s*$/, "").trim();
+  let body = output.replace(/\n?META:type=\w+,priority=\w+,risk=\w+,area=\w+\s*$/, "").trim();
+
+  // Strip any preamble text before "## Description"
+  const descriptionIndex = body.indexOf("## Description");
+  if (descriptionIndex > 0) {
+    body = body.substring(descriptionIndex);
+  }
+
+  return body;
 }


### PR DESCRIPTION
## Summary
- Updated `buildTicketPrompt` to explicitly instruct Claude to start output immediately with "## Description" without any preamble or commentary
- Enhanced `extractIssueBody` to strip any content appearing before the first "## Description" header as a safety measure
- Added unit tests to verify preamble text is properly stripped from generated issue bodies

## Test Plan
- [ ] Run unit tests with `npm test` to verify `extractIssueBody` correctly strips preamble text
- [ ] Run `gent create` with a description and verify the generated ticket starts cleanly with "## Description"
- [ ] Verify existing ticket creation functionality continues to work correctly

Closes #10
