### PR TITLE
Update the instructions to add a 'created with {provider}...

### DIFF
--- a/progress.txt
+++ b/progress.txt
@@ -24,3 +24,8 @@ Each entry documents: date, feature, decisions, files changed, tests, and concer
 - Files: src/types/index.ts, src/lib/config.ts, src/lib/ai-provider.ts, src/utils/validators.ts, src/utils/logger.ts, src/commands/run.ts, src/commands/create.ts, src/commands/pr.ts, src/commands/status.ts, src/index.ts, src/lib/ai-provider.test.ts, src/lib/config.test.ts
 - Changes: Added AIProvider type and AIConfig interface. Created ai-provider.ts abstraction layer supporting Claude and Gemini CLIs with auto-fallback on rate limits. Added --provider flag to run/create/pr commands. Updated status command to show AI provider info.
 - Decisions: Kept claude.ts for prompt building (backward compat), new ai-provider.ts handles invocation. GENT_AI_PROVIDER env var overrides config.
+
+[2026-01-11] #15 feat: add dynamic provider signature to issues and PRs
+- Files: src/commands/create.ts, src/commands/pr.ts
+- Changes: Appended "Created with {provider} by gent" footer to issue and PR bodies after AI generation.
+- Decisions: Footer added programmatically after AI response (not in prompt). Used existing getProviderDisplayName().

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -92,8 +92,8 @@ export async function createCommand(
       area: "shared",
     };
 
-    // Extract issue body (without META line)
-    const issueBody = extractIssueBody(aiOutput);
+    // Extract issue body (without META line) and append signature
+    const issueBody = extractIssueBody(aiOutput) + `\n\n---\n*Created with ${providerName} by [gent](https://github.com/Rotorsoft/gent)*`;
 
     // Generate title from description
     const title =

--- a/src/commands/pr.ts
+++ b/src/commands/pr.ts
@@ -124,6 +124,9 @@ export async function prCommand(options: PrOptions): Promise<void> {
     prBody = generateFallbackBody(issue, commits);
   }
 
+  // Append signature footer
+  prBody += `\n\n---\n*Created with ${providerName} by [gent](https://github.com/Rotorsoft/gent)*`;
+
   // Generate title
   const prTitle = issue?.title || commits[0] || currentBranch;
 


### PR DESCRIPTION
I will read the changes in `src/commands/create.ts` and `src/commands/pr.ts` to understand how the signature was added.

## Summary
- Added dynamic AI provider signatures to the bottom of generated GitHub Issues and Pull Requests.
- The signature automatically detects the active provider (e.g., Claude or Gemini) and appends a markdown footer with a link to the `gent` repository.
- Refactored `create` and `pr` commands to handle signature appending programmatically after AI response generation.

## Test Plan
- [ ] Run `gent create "New feature request"` and verify the preview and created issue contain the "Created with {provider} by gent" footer.
- [ ] Run `gent pr` on a feature branch and verify the generated PR description includes the correct provider signature.
- [ ] Switch providers in `.gent.yml` and confirm the signature updates to reflect the active provider.

Closes #15


---
*Created with Gemini by [gent](https://github.com/Rotorsoft/gent)*