### PR TITLE
Fix duplicate "Update available" message in status command

### DIFF
--- a/progress.txt
+++ b/progress.txt
@@ -95,3 +95,8 @@ Each entry documents: date, feature, decisions, files changed, tests, and concer
 - Files: src/commands/status.ts, src/lib/github.ts, src/lib/review-feedback.ts, src/lib/review-feedback.test.ts
 - Changes: Added getPrStatus() for PR state (open/closed/merged) and reviewDecision. Added countActionableFeedback() helper. Status now shows PR state, review decision, actionable comment counts with `gent fix` suggestion, and state-specific suggestions.
 - Decisions: Reused existing extractReviewFeedbackItems logic. Suggestions adapt based on PR state and feedback availability.
+
+[2026-01-15] #41 fix: duplicate "Update available" message in status command
+- Files: src/commands/status.ts
+- Changes: Removed duplicate update check from status command. The preAction hook in index.ts now handles update checks consistently for all commands.
+- Decisions: Single update check strategy via preAction hook; removed special-case logic from status command.

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -8,7 +8,7 @@ import { progressExists, readProgress } from "../lib/progress.js";
 import { configExists } from "../lib/config.js";
 import { checkGhAuth, checkClaudeCli, checkGeminiCli, checkGitRepo } from "../utils/validators.js";
 import { getProviderDisplayName } from "../lib/ai-provider.js";
-import { getVersion, checkForUpdates } from "../lib/version.js";
+import { getVersion } from "../lib/version.js";
 import { summarizeReviewFeedback, type ReviewFeedbackItem } from "../lib/review-feedback.js";
 
 function formatPrState(state: "open" | "closed" | "merged", isDraft: boolean): string {
@@ -59,14 +59,6 @@ function truncateFeedbackBody(body: string, maxLength: number): string {
 export async function statusCommand(): Promise<void> {
   const version = getVersion();
   logger.bold(`Gent Workflow Status ${colors.label(`v${version}`)}`);
-
-  // Check for updates (non-blocking, with short timeout for status command)
-  const versionCheck = await checkForUpdates();
-  if (versionCheck.updateAvailable && versionCheck.latestVersion) {
-    logger.warning(`  Update available: ${version} → ${versionCheck.latestVersion}`);
-    logger.dim(`  Run: npm install -g @rotorsoft/gent`);
-  }
-
   logger.newline();
 
   // Check prerequisites


### PR DESCRIPTION
## Summary
- Removed duplicate update check from the status command that was causing "Update available" message to display multiple times
- The update notification now appears exactly once per command invocation, improving the user experience

## Test Plan
- [ ] Run `gent status` when an update is available and verify the "Update available" message appears exactly once
- [ ] Run `gent status` when no update is available and verify no update message appears
- [ ] Verify other status command functionality works as expected (PR state, actionable comments, etc.)

Closes #41


---
*Created with Claude by [gent](https://github.com/Rotorsoft/gent)*