### PR TITLE
Add Playwright video capture for UI changes in completed tickets

### DIFF
--- a/progress.txt
+++ b/progress.txt
@@ -100,3 +100,8 @@ Each entry documents: date, feature, decisions, files changed, tests, and concer
 - Files: src/commands/status.ts
 - Changes: Removed duplicate update check from status command. The preAction hook in index.ts now handles update checks consistently for all commands.
 - Decisions: Single update check strategy via preAction hook; removed special-case logic from status command.
+
+[2026-01-26] #45 feat: add Playwright video capture for UI changes in PRs
+- Files: src/types/index.ts, src/lib/config.ts, src/lib/playwright.ts, src/lib/github-assets.ts, src/commands/pr.ts, src/index.ts, src/lib/playwright.test.ts, src/lib/github-assets.test.ts
+- Changes: Added VideoConfig type and configuration. Created playwright.ts for Playwright detection and UI change heuristics. When UI changes detected and Playwright available, adds instructions to AI prompt for video capture via MCP. Created github-assets.ts utility for future use.
+- Decisions: Video capture enabled by default, disabled via .gent.yml or --no-video. AI handles video capture autonomously via MCP (no manual URL needed). UI detection uses file patterns (tsx, vue, components/, pages/, etc).

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,8 +95,13 @@ program
   .description("Create an AI-enhanced pull request")
   .option("-d, --draft", "Create as draft PR")
   .option("-p, --provider <provider>", "AI provider to use (claude, gemini, or codex)")
+  .option("--no-video", "Disable video capture for UI changes")
   .action(async (options) => {
-    await prCommand({ draft: options.draft, provider: options.provider });
+    await prCommand({
+      draft: options.draft,
+      provider: options.provider,
+      video: options.video,
+    });
   });
 
 program

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -44,6 +44,12 @@ const DEFAULT_CONFIG: GentConfig = {
     provider: "claude",
     auto_fallback: true,
   },
+  video: {
+    enabled: true,
+    max_duration: 30,
+    width: 1280,
+    height: 720,
+  },
   validation: ["npm run typecheck", "npm run lint", "npm run test"],
 };
 
@@ -145,6 +151,10 @@ function mergeConfig(
       // Environment variable takes precedence
       ...(envProvider && { provider: envProvider }),
     },
+    video: {
+      ...defaults.video,
+      ...user.video,
+    },
     validation: user.validation ?? defaults.validation,
   };
 }
@@ -218,6 +228,13 @@ ai:
   provider: "${provider}"  # claude | gemini | codex
   # fallback_provider: "gemini"  # optional fallback when rate limited
   auto_fallback: true  # automatically switch to fallback on rate limit
+
+# Video capture for UI changes (requires Playwright)
+video:
+  enabled: true  # set to false to disable video capture for PRs with UI changes
+  max_duration: 30  # maximum video duration in seconds
+  width: 1280  # video width
+  height: 720  # video height
 
 # Validation commands (run before commit)
 validation:

--- a/src/lib/github-assets.test.ts
+++ b/src/lib/github-assets.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { formatVideoMarkdown } from "./github-assets.js";
+
+describe("github-assets", () => {
+  describe("formatVideoMarkdown", () => {
+    it("should format video URL as markdown with default title", () => {
+      const url = "https://github.com/user-attachments/assets/abc123.webm";
+      const markdown = formatVideoMarkdown(url);
+
+      expect(markdown).toContain("## Demo Video");
+      expect(markdown).toContain(url);
+      expect(markdown).toContain("<video");
+      expect(markdown).toContain("controls");
+    });
+
+    it("should use custom title when provided", () => {
+      const url = "https://github.com/user-attachments/assets/abc123.webm";
+      const markdown = formatVideoMarkdown(url, "UI Preview");
+
+      expect(markdown).toContain("## UI Preview");
+      expect(markdown).toContain(url);
+    });
+
+    it("should include video element with controls", () => {
+      const url = "https://github.com/user-attachments/assets/abc123.webm";
+      const markdown = formatVideoMarkdown(url);
+
+      expect(markdown).toContain(`<video src="${url}"`);
+      expect(markdown).toContain('controls');
+      expect(markdown).toContain('width="100%"');
+    });
+  });
+});

--- a/src/lib/github-assets.ts
+++ b/src/lib/github-assets.ts
@@ -1,0 +1,144 @@
+import { execa } from "execa";
+import { existsSync, statSync } from "node:fs";
+import { basename } from "node:path";
+
+export interface AssetUploadResult {
+  success: boolean;
+  url?: string;
+  error?: string;
+}
+
+/**
+ * Upload a file to GitHub as a release asset.
+ * Creates a hidden release for storing PR assets if needed.
+ */
+export async function uploadAsset(filePath: string): Promise<AssetUploadResult> {
+  if (!existsSync(filePath)) {
+    return { success: false, error: "File not found" };
+  }
+
+  const stats = statSync(filePath);
+  if (stats.size === 0) {
+    return { success: false, error: "File is empty" };
+  }
+
+  try {
+    // Get or create the assets release
+    const releaseTag = await getOrCreateAssetsRelease();
+    if (!releaseTag) {
+      return { success: false, error: "Failed to create assets release" };
+    }
+
+    const originalName = basename(filePath);
+
+    // Upload the asset
+    const { stdout, exitCode } = await execa(
+      "gh",
+      ["release", "upload", releaseTag, filePath, "--clobber"],
+      { reject: false }
+    );
+
+    if (exitCode !== 0) {
+      return { success: false, error: `Upload failed: ${stdout}` };
+    }
+
+    // Get the asset URL
+    const assetUrl = await getAssetUrl(releaseTag, originalName);
+    if (!assetUrl) {
+      return { success: false, error: "Failed to get asset URL" };
+    }
+
+    return { success: true, url: assetUrl };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    };
+  }
+}
+
+const ASSETS_RELEASE_TAG = "gent-assets";
+const ASSETS_RELEASE_NAME = "Gent PR Assets";
+
+/**
+ * Get or create a hidden release for storing PR assets
+ */
+async function getOrCreateAssetsRelease(): Promise<string | null> {
+  try {
+    // Check if release exists
+    const { exitCode } = await execa(
+      "gh",
+      ["release", "view", ASSETS_RELEASE_TAG],
+      { reject: false }
+    );
+
+    if (exitCode === 0) {
+      return ASSETS_RELEASE_TAG;
+    }
+
+    // Create the release
+    const { exitCode: createCode } = await execa(
+      "gh",
+      [
+        "release",
+        "create",
+        ASSETS_RELEASE_TAG,
+        "--title",
+        ASSETS_RELEASE_NAME,
+        "--notes",
+        "Auto-generated release for storing PR video assets. Do not delete.",
+        "--prerelease",
+      ],
+      { reject: false }
+    );
+
+    if (createCode === 0) {
+      return ASSETS_RELEASE_TAG;
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Get the download URL for an uploaded asset
+ */
+async function getAssetUrl(
+  releaseTag: string,
+  filename: string
+): Promise<string | null> {
+  try {
+    const { stdout } = await execa("gh", [
+      "release",
+      "view",
+      releaseTag,
+      "--json",
+      "assets",
+    ]);
+
+    const data = JSON.parse(stdout);
+    const asset = data.assets?.find(
+      (a: { name: string; url: string }) => a.name === filename
+    );
+
+    return asset?.url || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Format video URL for markdown embedding in PR description
+ */
+export function formatVideoMarkdown(url: string, title: string = "Demo Video"): string {
+  // GitHub markdown supports video embedding with a specific format
+  return `
+## ${title}
+
+https://github.com/user-attachments/assets/${url.split("/").pop()}
+
+<video src="${url}" controls width="100%"></video>
+`;
+}

--- a/src/lib/playwright.test.ts
+++ b/src/lib/playwright.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { hasUIChanges } from "./playwright.js";
+
+describe("playwright", () => {
+  describe("hasUIChanges", () => {
+    it("should detect .tsx files as UI changes", () => {
+      expect(hasUIChanges(["src/components/Button.tsx"])).toBe(true);
+      expect(hasUIChanges(["app/page.tsx"])).toBe(true);
+    });
+
+    it("should detect .jsx files as UI changes", () => {
+      expect(hasUIChanges(["src/App.jsx"])).toBe(true);
+    });
+
+    it("should detect .vue files as UI changes", () => {
+      expect(hasUIChanges(["src/components/Modal.vue"])).toBe(true);
+    });
+
+    it("should detect .svelte files as UI changes", () => {
+      expect(hasUIChanges(["src/routes/+page.svelte"])).toBe(true);
+    });
+
+    it("should detect CSS files as UI changes", () => {
+      expect(hasUIChanges(["src/styles/main.css"])).toBe(true);
+      expect(hasUIChanges(["src/components/Button.scss"])).toBe(true);
+      expect(hasUIChanges(["src/theme.less"])).toBe(true);
+    });
+
+    it("should detect components directory as UI changes", () => {
+      expect(hasUIChanges(["src/components/Header.ts"])).toBe(true);
+      expect(hasUIChanges(["components/Footer.js"])).toBe(true);
+    });
+
+    it("should detect pages directory as UI changes", () => {
+      expect(hasUIChanges(["src/pages/home.ts"])).toBe(true);
+      expect(hasUIChanges(["pages/index.js"])).toBe(true);
+    });
+
+    it("should detect views directory as UI changes", () => {
+      expect(hasUIChanges(["src/views/Dashboard.ts"])).toBe(true);
+    });
+
+    it("should detect layouts directory as UI changes", () => {
+      expect(hasUIChanges(["src/layouts/MainLayout.ts"])).toBe(true);
+    });
+
+    it("should detect ui directory as UI changes", () => {
+      expect(hasUIChanges(["src/ui/Card.ts"])).toBe(true);
+    });
+
+    it("should detect styles directory as UI changes", () => {
+      expect(hasUIChanges(["styles/global.ts"])).toBe(true);
+    });
+
+    it("should not detect backend files as UI changes", () => {
+      expect(hasUIChanges(["src/lib/api.ts"])).toBe(false);
+      expect(hasUIChanges(["src/utils/helpers.ts"])).toBe(false);
+      expect(hasUIChanges(["server/index.ts"])).toBe(false);
+    });
+
+    it("should not detect config files as UI changes", () => {
+      expect(hasUIChanges(["package.json"])).toBe(false);
+      expect(hasUIChanges(["tsconfig.json"])).toBe(false);
+      expect(hasUIChanges([".env"])).toBe(false);
+    });
+
+    it("should not detect test files as UI changes", () => {
+      expect(hasUIChanges(["src/lib/utils.test.ts"])).toBe(false);
+    });
+
+    it("should return false for empty file list", () => {
+      expect(hasUIChanges([])).toBe(false);
+    });
+
+    it("should detect UI changes in mixed file list", () => {
+      expect(
+        hasUIChanges([
+          "src/lib/api.ts",
+          "src/components/Button.tsx",
+          "README.md",
+        ])
+      ).toBe(true);
+    });
+
+    it("should be case-insensitive for directories", () => {
+      expect(hasUIChanges(["src/Components/Button.ts"])).toBe(true);
+      expect(hasUIChanges(["src/PAGES/home.ts"])).toBe(true);
+      expect(hasUIChanges(["UI/Card.ts"])).toBe(true);
+    });
+  });
+});

--- a/src/lib/playwright.ts
+++ b/src/lib/playwright.ts
@@ -1,0 +1,56 @@
+import { execa } from "execa";
+
+// UI file patterns that indicate UI changes
+const UI_FILE_PATTERNS = [
+  /\.(tsx|jsx)$/,
+  /\.(vue|svelte)$/,
+  /\.css$/,
+  /\.scss$/,
+  /\.less$/,
+  /\.styled\.(ts|js)$/,
+  /components?\//i,
+  /pages?\//i,
+  /views?\//i,
+  /layouts?\//i,
+  /ui\//i,
+  /styles?\//i,
+];
+
+/**
+ * Check if Playwright is available (installed locally or globally).
+ */
+export async function isPlaywrightAvailable(): Promise<boolean> {
+  try {
+    const { exitCode } = await execa("npx", ["playwright", "--version"], {
+      reject: false,
+    });
+    return exitCode === 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Detect if the changed files indicate UI changes
+ */
+export function hasUIChanges(changedFiles: string[]): boolean {
+  return changedFiles.some((file) =>
+    UI_FILE_PATTERNS.some((pattern) => pattern.test(file))
+  );
+}
+
+/**
+ * Get list of changed files from git diff
+ */
+export async function getChangedFiles(baseBranch: string = "main"): Promise<string[]> {
+  try {
+    const { stdout } = await execa("git", [
+      "diff",
+      `${baseBranch}...HEAD`,
+      "--name-only",
+    ]);
+    return stdout.trim().split("\n").filter(Boolean);
+  } catch {
+    return [];
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,7 +9,15 @@ export interface GentConfig {
   gemini: GeminiConfig;
   codex: CodexConfig;
   ai: AIConfig;
+  video: VideoConfig;
   validation: string[];
+}
+
+export interface VideoConfig {
+  enabled: boolean;
+  max_duration: number; // seconds
+  width: number;
+  height: number;
 }
 
 export interface AIConfig {


### PR DESCRIPTION
## Summary
- Add Playwright video capture for PRs with UI changes, with automatic detection of UI-related files (`.tsx`, `.vue`, `.svelte`, `components/`, `pages/`, etc.)
- Implement GitHub release-based asset upload for storing demo videos without committing them to the repository
- Add configurable video settings in `.gent.yml` (enabled, max_duration, resolution) with graceful degradation when Playwright is unavailable

## Test Plan
- [ ] Run unit tests for UI change detection heuristics (`npm run test src/lib/playwright.test.ts`)
- [ ] Run unit tests for video markdown formatting (`npm run test src/lib/github-assets.test.ts`)
- [ ] Verify Playwright availability detection works correctly with/without Playwright installed
- [ ] Create a test PR with UI changes (e.g., modify a `.tsx` file) and verify video capture prompt appears
- [ ] Test `--no-video` flag disables video capture
- [ ] Verify feature gracefully skips when Playwright is not available (warning message, PR creation continues)

Closes #45


---
*Created with Claude by [gent](https://github.com/Rotorsoft/gent)*