### PR TITLE
Hide implement action for merged PRs and replace refresh modal with inline refreshing indicator

### DIFF
--- a/progress.txt
+++ b/progress.txt
@@ -120,3 +120,8 @@ Each entry documents: date, feature, decisions, files changed, tests, and concer
 - Files: src/commands/list.ts, src/commands/list.test.ts, src/commands/run.ts, src/commands/tui.ts, src/tui/actions.ts, src/tui/actions.test.ts, src/index.ts, src/lib/git.ts, src/lib/github.ts
 - Changes: Consolidated `switch` and `list` commands into a single interactive `gent list` command. Displays tickets grouped by status (in progress, open PRs, ready) with branch switching on selection. Removed `--auto` flag and `autoSelectIssue` from run command. Removed separate `switch` command. TUI uses unified list action (shortcut l).
 - Decisions: Single command handles both listing and switching. Branch resolution scans local branches via parseBranchName, falls back to remote, offers creation if none found. Dirty working tree warning deferred until after selection.
+
+[2026-01-28] #53 fix: hide implement action for merged PRs and inline refresh indicator
+- Files: src/tui/actions.ts, src/tui/actions.test.ts, src/tui/display.ts, src/commands/tui.ts
+- Changes: Added PR merged state check to hide implement action. Replaced clear-screen modal refresh with inline "Refreshing…" label in dashboard title bar, re-rendering last state while loading new data.
+- Decisions: First load still uses modal since no previous state exists. Refreshing indicator shown in title row to avoid layout changes.

--- a/src/tui/actions.test.ts
+++ b/src/tui/actions.test.ts
@@ -221,6 +221,58 @@ describe("getAvailableActions", () => {
     expect(ids).toContain("checkout-main");
   });
 
+  it("does not show implement when PR is merged", () => {
+    const actions = getAvailableActions(createBaseState({
+      isOnMain: false,
+      branch: "ro/feature-123-test",
+      issue: {
+        number: 123,
+        title: "Test",
+        body: "Desc",
+        labels: ["ai-completed"],
+        state: "open",
+        url: "https://github.com/test/repo/issues/123",
+      },
+      pr: {
+        number: 456,
+        title: "Test PR",
+        url: "https://github.com/test/repo/pull/456",
+        state: "merged",
+        reviewDecision: null,
+        isDraft: false,
+      },
+    }));
+    const ids = actions.map((a) => a.id);
+
+    expect(ids).not.toContain("implement");
+  });
+
+  it("shows implement when PR is open", () => {
+    const actions = getAvailableActions(createBaseState({
+      isOnMain: false,
+      branch: "ro/feature-123-test",
+      issue: {
+        number: 123,
+        title: "Test",
+        body: "Desc",
+        labels: ["ai-in-progress"],
+        state: "open",
+        url: "https://github.com/test/repo/issues/123",
+      },
+      pr: {
+        number: 456,
+        title: "Test PR",
+        url: "https://github.com/test/repo/pull/456",
+        state: "open",
+        reviewDecision: null,
+        isDraft: false,
+      },
+    }));
+    const ids = actions.map((a) => a.id);
+
+    expect(ids).toContain("implement");
+  });
+
   it("does not show implement without issue on feature branch", () => {
     const actions = getAvailableActions(createBaseState({
       isOnMain: false,

--- a/src/tui/actions.ts
+++ b/src/tui/actions.ts
@@ -37,7 +37,7 @@ export function getAvailableActions(state: TuiState): TuiAction[] {
     actions.push({ id: "pr", label: "Create pr", shortcut: "C" });
   }
 
-  if (state.issue) {
+  if (state.issue && state.pr?.state !== "merged") {
     actions.push({ id: "implement", label: "implement", shortcut: "i" });
   }
 

--- a/src/tui/display.ts
+++ b/src/tui/display.ts
@@ -12,9 +12,6 @@ function termWidth(): number {
   return Math.min(process.stdout.columns || 80, 90);
 }
 
-function termHeight(): number {
-  return process.stdout.rows || 24;
-}
 
 function truncate(text: string, max: number): string {
   if (text.length <= max) return text;
@@ -136,30 +133,6 @@ function formatCommandBar(actions: TuiAction[], w: number): string[] {
   return lines;
 }
 
-// ── Modal ───────────────────────────────────────────────────────
-
-export function renderModal(message: string): void {
-  const w = termWidth();
-  const h = termHeight();
-  const modalW = Math.min(w - 4, Math.max(30, visibleLen(message) + 8));
-  const padX = Math.max(0, Math.floor((w - modalW) / 2));
-  const padY = Math.max(0, Math.floor((h - 5) / 2));
-  const indent = " ".repeat(padX);
-  const inner = modalW - 4;
-  const textPad = Math.max(0, inner - visibleLen(message));
-
-  const lines = [
-    indent + chalk.dim("┌" + "─".repeat(modalW - 2) + "┐"),
-    indent + chalk.dim("│") + " ".repeat(modalW - 2) + chalk.dim("│"),
-    indent + chalk.dim("│") + " " + chalk.bold(message) + " ".repeat(textPad) + " " + chalk.dim("│"),
-    indent + chalk.dim("│") + " ".repeat(modalW - 2) + chalk.dim("│"),
-    indent + chalk.dim("└" + "─".repeat(modalW - 2) + "┘"),
-  ];
-
-  // Position modal vertically centered
-  for (let i = 0; i < padY; i++) console.log();
-  for (const line of lines) console.log(line);
-}
 
 /**
  * Render a framed panel for action output.
@@ -190,12 +163,12 @@ function renderSettings(state: TuiState, w: number): void {
 
 // ── Main render ─────────────────────────────────────────────────
 
-export function renderDashboard(state: TuiState, actions: TuiAction[], hint?: string): void {
+export function renderDashboard(state: TuiState, actions: TuiAction[], hint?: string, refreshing?: boolean): void {
   const w = termWidth();
   const descMax = w - 8;
   const version = getVersion();
 
-  const titleLabel = `gent v${version}`;
+  const titleLabel = refreshing ? `gent v${version}  ${chalk.yellow("Refreshing…")}` : `gent v${version}`;
   console.log(topRow(titleLabel, w));
 
   // ── Error states ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Hide the "implement" action for merged PRs since it's no longer relevant once a PR has been merged
- Replace the intrusive screen-clearing refresh modal with an inline "Refreshing..." indicator that disables commands until the refresh completes
- Add unit tests verifying the implement action is excluded for merged PRs

## Test Plan
- [ ] Verify merged PRs no longer show the "implement" option in the dashboard actions
- [ ] Verify refreshing the dashboard displays an inline "Refreshing..." label instead of clearing the screen
- [ ] Verify all dashboard commands are disabled during a refresh and re-enabled once complete
- [ ] Run unit tests (`npm test`) to confirm the new action filtering tests pass

Closes #53


---
*Created with Claude by [gent](https://github.com/Rotorsoft/gent)*