### PR TITLE
Prefix dashboard list items with bullet markers and prevent text overflow

### DIFF
--- a/progress.txt
+++ b/progress.txt
@@ -170,9 +170,11 @@ Each entry documents: date, feature, decisions, files changed, tests, and concer
 
 
 [2026-01-30] #70 fix: show master/main branch in branch section with consistent UX
-
 - Files: src/tui/display.ts, src/tui/display.test.ts
-
 - Changes: Refactored dashboard rendering to always show the current branch in the branch section, including master/main. Hidden irrelevant sections (Ticket, PR, Commits) on main branch for a cleaner look.
-
 - Decisions: Integrated main branch into standard section-based layout while maintaining "ready to start new work" hint.
+
+[2026-01-30] #72 fix: prefix dashboard list items with bullet markers and prevent text overflow
+- Files: src/tui/display.ts, src/tui/modal.ts, src/tui/display.test.ts, src/tui/modal.test.ts
+- Changes: Added consistent `· ` bullet prefix to list items (commits, tickets, PRs) in dashboard and modal selectors. Implemented `truncateAnsi` in `display.ts` and updated `row()` to automatically truncate overflowing text with an ellipsis.
+- Decisions: Used `· ` for a clean TUI look. Centralized `truncateAnsi` in `display.ts` for reuse in modals.

--- a/src/tui/modal.test.ts
+++ b/src/tui/modal.test.ts
@@ -78,11 +78,11 @@ describe("buildSelectContent", () => {
     const lines = buildSelectContent(items, 1, 50);
     expect(lines.length).toBe(3);
 
-    // Selected item (index 1) should have ">" indicator
-    expect(stripAnsi(lines[1])).toMatch(/^>\s*Option B/);
-    // Non-selected items should not have ">"
-    expect(stripAnsi(lines[0])).toMatch(/^\s+Option A/);
-    expect(stripAnsi(lines[2])).toMatch(/^\s+Option C/);
+    // Selected item (index 1) should have ">" indicator and bullet
+    expect(stripAnsi(lines[1])).toMatch(/^>\s*·\s*Option B/);
+    // Non-selected items should not have ">" but should have bullet
+    expect(stripAnsi(lines[0])).toMatch(/^\s+·\s*Option A/);
+    expect(stripAnsi(lines[2])).toMatch(/^\s+·\s*Option C/);
   });
 
   it("handles separators without counting them as selectable", () => {
@@ -99,11 +99,11 @@ describe("buildSelectContent", () => {
     // First separator
     expect(stripAnsi(lines[0])).toContain("Group 1");
     // First selectable item (index 0) should be selected
-    expect(stripAnsi(lines[1])).toMatch(/^>\s*Option A/);
+    expect(stripAnsi(lines[1])).toMatch(/^>\s*·\s*Option A/);
     // Second separator
     expect(stripAnsi(lines[2])).toContain("Group 2");
     // Second selectable item (index 1) should not be selected
-    expect(stripAnsi(lines[3])).toMatch(/^\s+Option B/);
+    expect(stripAnsi(lines[3])).toMatch(/^\s+·\s*Option B/);
   });
 
   it("truncates long option names", () => {
@@ -112,7 +112,7 @@ describe("buildSelectContent", () => {
     ];
 
     const lines = buildSelectContent(items, 0, 20);
-    expect(stripAnsi(lines[0]).length).toBeLessThanOrEqual(22); // 20 + 2 for prefix
+    expect(stripAnsi(lines[0]).length).toBeLessThanOrEqual(24); // 20 + 4 for prefix (> · )
   });
 });
 

--- a/src/tui/modal.ts
+++ b/src/tui/modal.ts
@@ -1,5 +1,5 @@
 import chalk from "chalk";
-import { stripAnsi, visibleLen } from "./display.js";
+import { stripAnsi, visibleLen, truncateAnsi } from "./display.js";
 
 // ── Modal frame builders (pure, testable) ────────────────────────
 
@@ -19,27 +19,6 @@ function modalDivRow(w: number): string {
 
 function modalBotRow(w: number): string {
   return chalk.bold("└" + "─".repeat(w - 2) + "┘");
-}
-
-function truncateAnsi(text: string, max: number): string {
-  if (visibleLen(text) <= max) return text;
-  // Walk through the string, tracking visible characters
-  let visible = 0;
-  let i = 0;
-  while (i < text.length && visible < max - 1) {
-    if (text[i] === "\x1b") {
-      // Skip ANSI escape sequence
-      const end = text.indexOf("m", i);
-      if (end !== -1) {
-        i = end + 1;
-        continue;
-      }
-    }
-    visible++;
-    i++;
-  }
-  // Include any trailing ANSI reset sequences
-  return text.slice(0, i) + "\x1b[0m…";
 }
 
 function modalRow(text: string, w: number): string {
@@ -106,11 +85,10 @@ export function buildSelectContent(
     } else {
       const isSelected = selectableIdx === selectedIndex;
       const prefix = isSelected ? chalk.cyan.bold("> ") : "  ";
-      const label = item.name.length > maxWidth - 2
-        ? item.name.slice(0, maxWidth - 3) + "…"
-        : item.name;
+      const bullet = chalk.dim("· ");
+      const label = truncateAnsi(item.name, maxWidth - 4);
       lines.push(
-        prefix + (isSelected ? chalk.bold(label) : label)
+        prefix + bullet + (isSelected ? chalk.bold(label) : label)
       );
       selectableIdx++;
     }


### PR DESCRIPTION
## Summary
- Add bullet prefix (`· `) to all dashboard list items (commits, branches, issues, PRs) for consistent visual formatting
- Truncate long text with ellipsis (`…`) to prevent overflow past panel borders, accounting for prefix width and padding
- Refactor shared display utilities out of modal into reusable display module with comprehensive test coverage

## Test Plan
- [ ] Run unit tests (`pnpm test`) to verify truncation utility correctly appends ellipsis for strings exceeding available width
- [ ] Launch dashboard (`pnpm run dev`) with repos containing long commit messages and confirm no text overflows panel borders
- [ ] Verify bullet prefixes appear on all list items across dashboard panels
- [ ] Test at various terminal widths (80, 120, 160+ columns) to confirm correct rendering

Closes #72


---
*Created with Claude by [gent](https://github.com/Rotorsoft/gent)*