### PR TITLE
Improve hint section when not in a git repo and show quit command

### DIFF
--- a/progress.txt
+++ b/progress.txt
@@ -203,3 +203,8 @@ Each entry documents: date, feature, decisions, files changed, tests, and concer
 - Files: src/tui/actions.ts, src/tui/display.ts, src/tui/actions.test.ts, src/tui/display.test.ts, README.md
 - Changes: Remapped shortcuts: push `p`→`s` (send), PR `r`→`p`, run `u`→`r`. Changed command bar format from inline letter highlighting to explicit `[x]label` bracket notation. Updated tests and README.
 - Decisions: `s` for push (send/sync), `p` for PR, `r` for run — each action uses its natural first letter. Bracket notation is more explicit than coloring a letter within a word.
+
+[2026-01-31] #81 fix: improve hint section when not in a git repo
+- Files: src/tui/display.ts, src/tui/display.test.ts
+- Changes: Render command bar (with quit shortcut) in non-git-repo and non-authenticated error states instead of closing the box early. Improved non-git message to "Navigate to a git repository to get started".
+- Decisions: Changed error color from red to yellow for non-git state since it's informational, not an error. Applied same command bar fix to the non-authenticated state for consistency.

--- a/src/tui/display.test.ts
+++ b/src/tui/display.test.ts
@@ -202,6 +202,48 @@ describe("display", () => {
       expect(output).not.toContain("Update available");
     });
 
+    it("renders helpful message and quit command when not in a git repo", () => {
+      const state: TuiState = {
+        ...mockBaseState,
+        isGitRepo: false,
+        isGhAuthenticated: false,
+        branch: "",
+        isOnMain: false,
+      };
+
+      const quitAction: TuiAction[] = [
+        { id: "quit", label: "quit", shortcut: "q" },
+      ];
+
+      const lines = buildDashboardLines(state, quitAction).map(stripAnsi);
+      const output = lines.join("\n");
+
+      expect(output).toContain("Not a git repository");
+      expect(output).toContain("Navigate to a git repository to get started");
+      expect(output).toContain("quit");
+      // Should not render git-specific sections
+      expect(output).not.toContain("Branch");
+      expect(output).not.toContain("Ticket");
+      expect(output).not.toContain("Commits");
+    });
+
+    it("renders quit command when GitHub CLI not authenticated", () => {
+      const state: TuiState = {
+        ...mockBaseState,
+        isGhAuthenticated: false,
+      };
+
+      const quitAction: TuiAction[] = [
+        { id: "quit", label: "quit", shortcut: "q" },
+      ];
+
+      const lines = buildDashboardLines(state, quitAction).map(stripAnsi);
+      const output = lines.join("\n");
+
+      expect(output).toContain("GitHub CLI not authenticated");
+      expect(output).toContain("quit");
+    });
+
     it("renders bullets for list items", () => {
       const state: TuiState = {
         ...mockBaseState,

--- a/src/tui/display.ts
+++ b/src/tui/display.ts
@@ -244,14 +244,22 @@ export function buildDashboardLines(
 
   // ── Error states ──────────────────────────────────────────────
   if (!state.isGitRepo) {
-    out(row(chalk.red("Not a git repository"), w));
-    out(row(chalk.dim("Run gent init in a git repo to get started"), w));
+    out(row(chalk.yellow("Not a git repository"), w));
+    out(row(chalk.dim("Navigate to a git repository to get started"), w));
+    out(divRow(w));
+    for (const line of formatCommandBar(actions, w)) {
+      out(row(line, w));
+    }
     out(botRow(w));
     return lines;
   }
   if (!state.isGhAuthenticated) {
     out(row(chalk.red("GitHub CLI not authenticated"), w));
     out(row(chalk.dim("Run: gh auth login"), w));
+    out(divRow(w));
+    for (const line of formatCommandBar(actions, w)) {
+      out(row(line, w));
+    }
     out(botRow(w));
     return lines;
   }


### PR DESCRIPTION
## Summary
- Show an improved hint message when `gent` is launched outside a git repo, guiding users to navigate to a git repository
- Always display the quit command (`q`) in the command bar regardless of git repo status
- Add unit tests verifying hint rendering behavior for both git and non-git contexts

## Test Plan
- [ ] Run `gent` outside a git repository and confirm the hint section shows "Navigate to a git repository to get started" with the quit command visible
- [ ] Run `gent` inside a git repository and confirm existing hint behavior is unchanged
- [ ] Run unit tests (`npm test`) and verify the new display tests pass

Closes #81


---
*Created with Claude by [gent](https://github.com/Rotorsoft/gent)*