### PR TITLE
Gate "new" and "pr" actions on valid git remote and show hint in TUI

### DIFF
--- a/progress.txt
+++ b/progress.txt
@@ -213,3 +213,8 @@ Each entry documents: date, feature, decisions, files changed, tests, and concer
 - Files: src/tui/modal.ts, src/tui/modal.test.ts
 - Changes: Added cursor position tracking, arrow key navigation (left/right/up/down across visual lines), Home/End/Ctrl+A/Ctrl+E, Ctrl+Left/Right word jump, Delete key, mid-text insertion/deletion. Added visual line mapping (getVisualLines, findCursorVisualPos) for cursor-to-screen coordinate translation through word-wrap. Decoded new ANSI sequences in readKey().
 - Decisions: Replaced wrapLine with wrapLineWithMap that tracks character offsets through word-wrap breaks. Cursor movement helpers are exported pure functions for testability. Kept cursorPos optional in buildMultilineInputContent for backward compatibility.
+
+[2026-01-31] #85 feat: gate new and pr actions on valid git remote
+- Files: src/tui/state.ts, src/tui/actions.ts, src/tui/display.ts, src/tui/actions.test.ts, src/tui/state.test.ts, src/tui/display.test.ts, src/commands/tui.ts, src/commands/tui.test.ts
+- Changes: Added `hasValidRemote` field to TuiState, populated via `getRepoInfo()`. Gated "new" and "pr" actions on valid remote. Added hint in display when remote is missing.
+- Decisions: Reused existing `getRepoInfo()` from git.ts. Remote check runs in parallel with other git state queries. Hint displayed in dedicated section, takes priority over custom hints.

--- a/src/commands/tui.test.ts
+++ b/src/commands/tui.test.ts
@@ -98,6 +98,7 @@ describe("executeAction", () => {
       hasActionableFeedback: false,
       hasUIChanges: false,
       isPlaywrightAvailable: false,
+      hasValidRemote: true,
     };
   });
 

--- a/src/commands/tui.ts
+++ b/src/commands/tui.ts
@@ -600,6 +600,7 @@ export async function tuiCommand(): Promise<void> {
     hasActionableFeedback: false,
     hasUIChanges: false,
     isPlaywrightAvailable: false,
+    hasValidRemote: true,
   };
 
   let needsRefresh = true;

--- a/src/tui/actions.test.ts
+++ b/src/tui/actions.test.ts
@@ -56,6 +56,7 @@ function createBaseState(overrides: Partial<TuiState> = {}): TuiState {
     hasActionableFeedback: false,
     hasUIChanges: false,
     isPlaywrightAvailable: false,
+    hasValidRemote: true,
     ...overrides,
   };
 }
@@ -314,6 +315,40 @@ describe("getAvailableActions", () => {
     const ids = actions.map((a) => a.id);
 
     expect(ids).toContain("quit");
+  });
+
+  it("hides create and pr actions when hasValidRemote is false", () => {
+    const actions = getAvailableActions(
+      createBaseState({
+        hasValidRemote: false,
+        isOnMain: false,
+        branch: "ro/feature-123-test",
+        commits: ["feat: test"],
+      })
+    );
+    const ids = actions.map((a) => a.id);
+
+    expect(ids).not.toContain("create");
+    expect(ids).not.toContain("pr");
+    // Other actions should still be present
+    expect(ids).toContain("list");
+    expect(ids).toContain("refresh");
+    expect(ids).toContain("quit");
+  });
+
+  it("shows create and pr actions when hasValidRemote is true", () => {
+    const actions = getAvailableActions(
+      createBaseState({
+        hasValidRemote: true,
+        isOnMain: false,
+        branch: "ro/feature-123-test",
+        commits: ["feat: test"],
+      })
+    );
+    const ids = actions.map((a) => a.id);
+
+    expect(ids).toContain("create");
+    expect(ids).toContain("pr");
   });
 
   it("has unique shortcuts per action set", () => {

--- a/src/tui/actions.ts
+++ b/src/tui/actions.ts
@@ -14,8 +14,10 @@ export function getAvailableActions(state: TuiState): TuiAction[] {
     return actions;
   }
 
-  // Common actions available everywhere
-  actions.push({ id: "create", label: "new", shortcut: "n" });
+  // Common actions available everywhere (gated on valid remote for GitHub-dependent actions)
+  if (state.hasValidRemote) {
+    actions.push({ id: "create", label: "new", shortcut: "n" });
+  }
 
   // On feature branch - add context-aware actions BEFORE other common actions
   if (!state.isOnMain) {
@@ -27,7 +29,7 @@ export function getAvailableActions(state: TuiState): TuiAction[] {
       actions.push({ id: "push", label: "push", shortcut: "s" });
     }
 
-    if (!state.pr && state.commits.length > 0) {
+    if (state.hasValidRemote && !state.pr && state.commits.length > 0) {
       actions.push({ id: "pr", label: "pr", shortcut: "p" });
     }
 

--- a/src/tui/display.test.ts
+++ b/src/tui/display.test.ts
@@ -51,6 +51,7 @@ const mockBaseState: TuiState = {
   hasActionableFeedback: false,
   hasUIChanges: false,
   isPlaywrightAvailable: false,
+  hasValidRemote: true,
 };
 
 const mockActions: TuiAction[] = [
@@ -242,6 +243,39 @@ describe("display", () => {
 
       expect(output).toContain("GitHub CLI not authenticated");
       expect(output).toContain("quit");
+    });
+
+    it("renders hint when hasValidRemote is false in a git repo", () => {
+      const state: TuiState = {
+        ...mockBaseState,
+        branch: "main",
+        isOnMain: true,
+        hasValidRemote: false,
+      };
+
+      const lines = buildDashboardLines(state, mockActions).map(stripAnsi);
+      const output = lines.join("\n");
+
+      expect(output).toContain("Hint");
+      expect(output).toContain(
+        "Add a GitHub remote to create tickets and pull requests"
+      );
+    });
+
+    it("does not render remote hint when hasValidRemote is true", () => {
+      const state: TuiState = {
+        ...mockBaseState,
+        branch: "main",
+        isOnMain: true,
+        hasValidRemote: true,
+      };
+
+      const lines = buildDashboardLines(state, mockActions).map(stripAnsi);
+      const output = lines.join("\n");
+
+      expect(output).not.toContain(
+        "Add a GitHub remote to create tickets and pull requests"
+      );
     });
 
     it("renders bullets for list items", () => {

--- a/src/tui/display.ts
+++ b/src/tui/display.ts
@@ -385,7 +385,17 @@ export function buildDashboardLines(
   }
 
   // Hint
-  if (hint) {
+  if (!state.hasValidRemote) {
+    section("Hint");
+    out(
+      row(
+        chalk.yellow(
+          "Add a GitHub remote to create tickets and pull requests"
+        ),
+        w
+      )
+    );
+  } else if (hint) {
     section("Hint");
     out(row(chalk.yellow(hint), w));
   }

--- a/src/tui/state.test.ts
+++ b/src/tui/state.test.ts
@@ -52,6 +52,7 @@ vi.mock("../lib/git.js", () => ({
   getCommitsSinceBase: vi.fn(),
   getDefaultBranch: vi.fn(),
   getLastCommitTimestamp: vi.fn(),
+  getRepoInfo: vi.fn(),
 }));
 
 vi.mock("../lib/branch.js", () => ({
@@ -121,6 +122,10 @@ describe("aggregateState", () => {
     vi.mocked(git.getDefaultBranch).mockResolvedValue("main");
     vi.mocked(git.getCommitsSinceBase).mockResolvedValue([]);
     vi.mocked(git.getUnpushedCommits).mockResolvedValue(false);
+    vi.mocked(git.getRepoInfo).mockResolvedValue({
+      owner: "test",
+      repo: "repo",
+    });
     vi.mocked(branch.parseBranchName).mockReturnValue(null);
 
     const state = await aggregateState();
@@ -130,6 +135,25 @@ describe("aggregateState", () => {
     expect(state.branch).toBe("main");
     expect(state.issue).toBeNull();
     expect(state.pr).toBeNull();
+    expect(state.hasValidRemote).toBe(true);
+  });
+
+  it("sets hasValidRemote to false when no remote configured", async () => {
+    vi.mocked(validators.checkGitRepo).mockResolvedValue(true);
+    vi.mocked(validators.checkGhAuth).mockResolvedValue(true);
+    vi.mocked(validators.checkAIProvider).mockResolvedValue(true);
+    vi.mocked(git.getCurrentBranch).mockResolvedValue("main");
+    vi.mocked(git.isOnMainBranch).mockResolvedValue(true);
+    vi.mocked(git.hasUncommittedChanges).mockResolvedValue(false);
+    vi.mocked(git.getDefaultBranch).mockResolvedValue("main");
+    vi.mocked(git.getCommitsSinceBase).mockResolvedValue([]);
+    vi.mocked(git.getUnpushedCommits).mockResolvedValue(false);
+    vi.mocked(git.getRepoInfo).mockResolvedValue(null);
+    vi.mocked(branch.parseBranchName).mockReturnValue(null);
+
+    const state = await aggregateState();
+
+    expect(state.hasValidRemote).toBe(false);
   });
 
   it("detects feature branch with issue correctly", async () => {
@@ -140,6 +164,10 @@ describe("aggregateState", () => {
     vi.mocked(git.isOnMainBranch).mockResolvedValue(false);
     vi.mocked(git.hasUncommittedChanges).mockResolvedValue(true);
     vi.mocked(git.getDefaultBranch).mockResolvedValue("main");
+    vi.mocked(git.getRepoInfo).mockResolvedValue({
+      owner: "test",
+      repo: "repo",
+    });
     vi.mocked(git.getCommitsSinceBase).mockResolvedValue([
       "feat: add TUI",
       "fix: typo",
@@ -190,6 +218,10 @@ describe("aggregateState", () => {
     vi.mocked(git.isOnMainBranch).mockResolvedValue(false);
     vi.mocked(git.hasUncommittedChanges).mockResolvedValue(false);
     vi.mocked(git.getDefaultBranch).mockResolvedValue("main");
+    vi.mocked(git.getRepoInfo).mockResolvedValue({
+      owner: "test",
+      repo: "repo",
+    });
     vi.mocked(git.getCommitsSinceBase).mockResolvedValue(["feat: add TUI"]);
     vi.mocked(git.getUnpushedCommits).mockResolvedValue(false);
     vi.mocked(git.getLastCommitTimestamp).mockResolvedValue(
@@ -252,6 +284,10 @@ describe("aggregateState", () => {
     vi.mocked(git.isOnMainBranch).mockResolvedValue(true);
     vi.mocked(git.hasUncommittedChanges).mockResolvedValue(false);
     vi.mocked(git.getDefaultBranch).mockResolvedValue("main");
+    vi.mocked(git.getRepoInfo).mockResolvedValue({
+      owner: "test",
+      repo: "repo",
+    });
     vi.mocked(git.getCommitsSinceBase).mockResolvedValue([]);
     vi.mocked(git.getUnpushedCommits).mockResolvedValue(false);
     vi.mocked(branch.parseBranchName).mockReturnValue(null);


### PR DESCRIPTION
## Summary
- Gate "new" and "pr" TUI actions behind a valid GitHub remote check, hiding them when no remote is configured
- Display a helpful hint ("Add a GitHub remote to create tickets and pull requests") when the user is in a git repo without a valid remote
- Add unit tests for the new gating logic in actions, display, and state modules

## Test Plan
- [ ] Unit tests pass for `getAvailableActions()` excluding "new" and "pr" when `hasValidRemote` is `false`
- [ ] Unit tests pass for hint display when `hasValidRemote` is `false` and `isGitRepo` is `true`
- [ ] Unit tests pass for `aggregateState()` setting `hasValidRemote` correctly
- [ ] Manual: Initialize a git repo without a remote, run `gent`, confirm "new" and "pr" are hidden and hint is displayed
- [ ] Manual: Add a GitHub remote, refresh dashboard, confirm actions reappear and hint disappears
- [ ] No regression: all actions behave normally when a valid remote is present

Closes #85


---
*Created with Claude by [gent](https://github.com/Rotorsoft/gent)*