### PR TITLE
Hide list command and add push-remote command when no git remote is configured

### DIFF
--- a/progress.txt
+++ b/progress.txt
@@ -218,3 +218,8 @@ Each entry documents: date, feature, decisions, files changed, tests, and concer
 - Files: src/tui/state.ts, src/tui/actions.ts, src/tui/display.ts, src/tui/actions.test.ts, src/tui/state.test.ts, src/tui/display.test.ts, src/commands/tui.ts, src/commands/tui.test.ts
 - Changes: Added `hasValidRemote` field to TuiState, populated via `getRepoInfo()`. Gated "new" and "pr" actions on valid remote. Added hint in display when remote is missing.
 - Decisions: Reused existing `getRepoInfo()` from git.ts. Remote check runs in parallel with other git state queries. Hint displayed in dedicated section, takes priority over custom hints.
+
+[2026-01-31] #87 feat: hide list command and add github-remote command
+- Files: src/tui/actions.ts, src/tui/display.ts, src/commands/github-remote.ts, src/commands/tui.ts, src/index.ts, src/tui/actions.test.ts, src/tui/display.test.ts, progress.txt
+- Changes: Gated `list` action on `hasValidRemote`. Added `github-remote` action (shortcut `g`) visible when no remote exists. Created `github-remote` command using `gh repo create --source=. --push --private`. Registered CLI command and TUI handler with confirmation modal.
+- Decisions: Used `gh repo create --source=. --push --private` for single-command repo creation + push. Shortcut `g` (GitHub) to avoid conflicts with existing shortcuts.

--- a/src/commands/github-remote.ts
+++ b/src/commands/github-remote.ts
@@ -1,0 +1,40 @@
+import { execa } from "execa";
+import { logger } from "../utils/logger.js";
+import { getCurrentBranch } from "../lib/git.js";
+import { checkGhAuth } from "../utils/validators.js";
+
+export async function githubRemoteCommand(): Promise<boolean> {
+  const isAuthenticated = await checkGhAuth();
+  if (!isAuthenticated) {
+    logger.error("GitHub CLI is not authenticated. Run: gh auth login");
+    return false;
+  }
+
+  try {
+    // Check if remote origin already exists
+    try {
+      const { stdout } = await execa("git", [
+        "config",
+        "--get",
+        "remote.origin.url",
+      ]);
+      if (stdout.trim()) {
+        logger.error("Remote origin already exists: " + stdout.trim());
+        return false;
+      }
+    } catch {
+      // No remote origin — expected
+    }
+
+    // Create a GitHub repo using gh CLI (uses current directory name)
+    logger.info("Creating GitHub repository...");
+    await execa("gh", ["repo", "create", "--source=.", "--push", "--private"]);
+
+    const branch = await getCurrentBranch();
+    logger.success(`Repository created and ${branch} pushed to GitHub`);
+    return true;
+  } catch (error) {
+    logger.error(`Failed to create remote: ${error}`);
+    return false;
+  }
+}

--- a/src/commands/tui.ts
+++ b/src/commands/tui.ts
@@ -20,6 +20,7 @@ import { logger } from "../utils/logger.js";
 import { createCommand } from "./create.js";
 import { prCommand } from "./pr.js";
 import { buildTicketChoices } from "./list.js";
+import { githubRemoteCommand } from "./github-remote.js";
 import {
   buildCommitMessagePrompt,
   buildImplementationPrompt,
@@ -141,6 +142,18 @@ export async function executeAction(
 
     case "run": {
       await handleRun(state);
+      return CONTINUE;
+    }
+
+    case "github-remote": {
+      const confirmed = await showConfirm({
+        title: "Push to GitHub",
+        message: "Create a private GitHub repo and push?",
+        dashboardLines,
+      });
+      if (!confirmed) return SKIP_REFRESH;
+      showStatus("Pushing", "Creating GitHub repo and pushing...", dashboardLines);
+      await githubRemoteCommand();
       return CONTINUE;
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { prCommand } from "./commands/pr.js";
 import { fixCommand } from "./commands/fix.js";
 import { statusCommand } from "./commands/status.js";
 import { tuiCommand } from "./commands/tui.js";
+import { githubRemoteCommand } from "./commands/github-remote.js";
 import {
   getVersion,
   checkForUpdates,
@@ -144,6 +145,13 @@ program
   .description("Show current workflow status")
   .action(async () => {
     await statusCommand();
+  });
+
+program
+  .command("github-remote")
+  .description("Create a GitHub repository and push local repo")
+  .action(async () => {
+    await githubRemoteCommand();
   });
 
 program

--- a/src/tui/actions.test.ts
+++ b/src/tui/actions.test.ts
@@ -317,7 +317,7 @@ describe("getAvailableActions", () => {
     expect(ids).toContain("quit");
   });
 
-  it("hides create and pr actions when hasValidRemote is false", () => {
+  it("hides create, pr, and list actions when hasValidRemote is false", () => {
     const actions = getAvailableActions(
       createBaseState({
         hasValidRemote: false,
@@ -330,13 +330,14 @@ describe("getAvailableActions", () => {
 
     expect(ids).not.toContain("create");
     expect(ids).not.toContain("pr");
-    // Other actions should still be present
-    expect(ids).toContain("list");
+    expect(ids).not.toContain("list");
+    // github-remote should be available instead of list
+    expect(ids).toContain("github-remote");
     expect(ids).toContain("refresh");
     expect(ids).toContain("quit");
   });
 
-  it("shows create and pr actions when hasValidRemote is true", () => {
+  it("shows create, pr, and list actions when hasValidRemote is true", () => {
     const actions = getAvailableActions(
       createBaseState({
         hasValidRemote: true,
@@ -349,6 +350,8 @@ describe("getAvailableActions", () => {
 
     expect(ids).toContain("create");
     expect(ids).toContain("pr");
+    expect(ids).toContain("list");
+    expect(ids).not.toContain("github-remote");
   });
 
   it("has unique shortcuts per action set", () => {

--- a/src/tui/actions.ts
+++ b/src/tui/actions.ts
@@ -39,7 +39,11 @@ export function getAvailableActions(state: TuiState): TuiAction[] {
   }
 
   // Common navigation/config actions
-  actions.push({ id: "list", label: "list", shortcut: "l" });
+  if (state.hasValidRemote) {
+    actions.push({ id: "list", label: "list", shortcut: "l" });
+  } else {
+    actions.push({ id: "github-remote", label: "github", shortcut: "g" });
+  }
   actions.push({ id: "refresh", label: "refresh", shortcut: "f" });
   actions.push({ id: "switch-provider", label: "ai", shortcut: "a" });
   actions.push({ id: "quit", label: "quit", shortcut: "q" });

--- a/src/tui/display.test.ts
+++ b/src/tui/display.test.ts
@@ -258,7 +258,7 @@ describe("display", () => {
 
       expect(output).toContain("Hint");
       expect(output).toContain(
-        "Add a GitHub remote to create tickets and pull requests"
+        "Press [g] to create a GitHub repo and push"
       );
     });
 
@@ -274,7 +274,7 @@ describe("display", () => {
       const output = lines.join("\n");
 
       expect(output).not.toContain(
-        "Add a GitHub remote to create tickets and pull requests"
+        "Press [g] to create a GitHub repo and push"
       );
     });
 

--- a/src/tui/display.ts
+++ b/src/tui/display.ts
@@ -390,7 +390,7 @@ export function buildDashboardLines(
     out(
       row(
         chalk.yellow(
-          "Add a GitHub remote to create tickets and pull requests"
+          "Press [g] to create a GitHub repo and push"
         ),
         w
       )


### PR DESCRIPTION
## Summary
- Hide the `list` command/action from the TUI dashboard when no valid git remote is configured, following the pattern established in #85
- Add a new `github-remote` command that creates a GitHub repository and configures it as the remote origin, accessible from both CLI and TUI
- Show the `github-remote` action in the TUI dashboard only when no remote is currently configured

## Test Plan
- [ ] Run `gent` in a repository with no git remote configured and verify `list` is hidden and `github-remote` is available in the TUI
- [ ] Run `gent` in a repository with a valid git remote and verify `list` is visible and `github-remote` is not shown
- [ ] Run `gent github-remote` in a repo without a remote and verify it creates a GitHub repo and adds the remote
- [ ] Verify existing unit tests pass (`actions.test.ts`, `display.test.ts`)

Closes #87

---
*Created with Claude by [gent](https://github.com/Rotorsoft/gent)*


---
*Created with Claude by [gent](https://github.com/Rotorsoft/gent)*