### PR TITLE
Show init/setup hints when repo is not initialized and hide dependent commands

### DIFF
--- a/progress.txt
+++ b/progress.txt
@@ -228,3 +228,8 @@ Each entry documents: date, feature, decisions, files changed, tests, and concer
 - Files: src/utils/spinner.ts, src/lib/ai-provider.ts, src/commands/create.ts, src/commands/run.ts, src/commands/pr.ts, src/commands/fix.ts, src/commands/tui.ts
 - Changes: Added `aiSpinnerText(provider, action)` helper and real ora spinners for AI wait states. Removed old "Creating AI-enhanced..." header messages. Added `onFirstData` callback to streaming providers so spinner stops when AI starts responding.
 - Decisions: Used `onFirstData` callback in `AIProviderOptions` to cleanly stop spinner on first streaming output. Interactive commands stop spinner before handing over stdio.
+
+[2026-02-02] #89 feat: show init/setup hints when repo is not initialized
+- Files: src/utils/validators.ts, src/lib/github.ts, src/tui/state.ts, src/tui/actions.ts, src/tui/display.ts, src/commands/tui.ts, src/index.ts, src/lib/github.test.ts, src/tui/actions.test.ts, src/tui/display.test.ts, src/tui/state.test.ts, src/utils/validators.test.ts, src/commands/tui.test.ts
+- Changes: Added `checkInitialized()` validator and `checkLabelsExist()` GitHub check. Added `hasLabels` to TUI state with session-level caching. Gated workflow actions (create, list, run, pr) on init+labels status. Added setup banners and init/setup-labels actions to TUI. Guarded CLI commands with prerequisite checks showing clear hints.
+- Decisions: Labels check cached per session (like other env checks). Git operations (commit, push) remain available without labels. Labels check deferred until config and remote both exist.

--- a/src/commands/tui.test.ts
+++ b/src/commands/tui.test.ts
@@ -99,6 +99,7 @@ describe("executeAction", () => {
       hasUIChanges: false,
       isPlaywrightAvailable: false,
       hasValidRemote: true,
+      hasLabels: true,
     };
   });
 

--- a/src/commands/tui.ts
+++ b/src/commands/tui.ts
@@ -1,5 +1,5 @@
 import { execa } from "execa";
-import { aggregateState, type TuiState } from "../tui/state.js";
+import { aggregateState, resetEnvCache, type TuiState } from "../tui/state.js";
 import { getAvailableActions, type TuiAction } from "../tui/actions.js";
 import {
   renderDashboard,
@@ -19,6 +19,8 @@ import { checkForUpdates, type VersionCheckResult } from "../lib/version.js";
 import { logger } from "../utils/logger.js";
 import { aiSpinnerText } from "../utils/spinner.js";
 import { createCommand } from "./create.js";
+import { initCommand } from "./init.js";
+import { setupLabelsCommand } from "./setup-labels.js";
 import { prCommand } from "./pr.js";
 import { buildTicketChoices } from "./list.js";
 import { githubRemoteCommand } from "./github-remote.js";
@@ -143,6 +145,28 @@ export async function executeAction(
 
     case "run": {
       await handleRun(state);
+      return CONTINUE;
+    }
+
+    case "init": {
+      clearScreen();
+      try {
+        await initCommand({});
+      } catch (error) {
+        logger.error(`Init failed: ${error}`);
+      }
+      resetEnvCache();
+      return CONTINUE;
+    }
+
+    case "setup-labels": {
+      clearScreen();
+      try {
+        await setupLabelsCommand();
+      } catch (error) {
+        logger.error(`Setup labels failed: ${error}`);
+      }
+      resetEnvCache();
       return CONTINUE;
     }
 
@@ -615,6 +639,7 @@ export async function tuiCommand(): Promise<void> {
     hasUIChanges: false,
     isPlaywrightAvailable: false,
     hasValidRemote: true,
+    hasLabels: true,
   };
 
   let needsRefresh = true;

--- a/src/lib/github.test.ts
+++ b/src/lib/github.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from "vitest";
+import { execa } from "execa";
+import { checkLabelsExist } from "./github.js";
+
+vi.mock("execa");
+
+describe("checkLabelsExist", () => {
+  it("returns true when all workflow labels exist", async () => {
+    vi.mocked(execa).mockResolvedValue({
+      stdout: JSON.stringify([
+        { name: "ai-ready" },
+        { name: "ai-in-progress" },
+        { name: "ai-completed" },
+        { name: "ai-blocked" },
+        { name: "type:feature" },
+      ]),
+    } as any);
+
+    expect(await checkLabelsExist()).toBe(true);
+  });
+
+  it("returns false when some workflow labels are missing", async () => {
+    vi.mocked(execa).mockResolvedValue({
+      stdout: JSON.stringify([
+        { name: "ai-ready" },
+        { name: "type:feature" },
+      ]),
+    } as any);
+
+    expect(await checkLabelsExist()).toBe(false);
+  });
+
+  it("returns false when no labels exist", async () => {
+    vi.mocked(execa).mockResolvedValue({
+      stdout: "[]",
+    } as any);
+
+    expect(await checkLabelsExist()).toBe(false);
+  });
+
+  it("returns false when gh command fails", async () => {
+    vi.mocked(execa).mockRejectedValue(new Error("gh not found"));
+
+    expect(await checkLabelsExist()).toBe(false);
+  });
+});

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -5,6 +5,31 @@ import type {
   GitHubReviewData,
 } from "../types/index.js";
 
+const WORKFLOW_LABELS = [
+  "ai-ready",
+  "ai-in-progress",
+  "ai-completed",
+  "ai-blocked",
+];
+
+export async function checkLabelsExist(): Promise<boolean> {
+  try {
+    const { stdout } = await execa("gh", [
+      "label",
+      "list",
+      "--json",
+      "name",
+      "--limit",
+      "200",
+    ]);
+    const labels: { name: string }[] = JSON.parse(stdout);
+    const names = new Set(labels.map((l) => l.name));
+    return WORKFLOW_LABELS.every((wl) => names.has(wl));
+  } catch {
+    return false;
+  }
+}
+
 export async function getIssue(issueNumber: number): Promise<GitHubIssue> {
   const { stdout } = await execa("gh", [
     "issue",

--- a/src/tui/actions.ts
+++ b/src/tui/actions.ts
@@ -14,8 +14,21 @@ export function getAvailableActions(state: TuiState): TuiAction[] {
     return actions;
   }
 
+  // Setup actions when prerequisites are missing
+  const needsInit = !state.hasConfig;
+  const needsLabels = state.hasConfig && state.hasValidRemote && !state.hasLabels;
+
+  if (needsInit) {
+    actions.push({ id: "init", label: "init", shortcut: "i" });
+  } else if (needsLabels) {
+    actions.push({ id: "setup-labels", label: "setup-labels", shortcut: "b" });
+  }
+
+  // Only show workflow actions when fully set up
+  const isSetUp = state.hasConfig && (!state.hasValidRemote || state.hasLabels);
+
   // Common actions available everywhere (gated on valid remote for GitHub-dependent actions)
-  if (state.hasValidRemote) {
+  if (isSetUp && state.hasValidRemote) {
     actions.push({ id: "create", label: "new", shortcut: "n" });
   }
 
@@ -29,19 +42,19 @@ export function getAvailableActions(state: TuiState): TuiAction[] {
       actions.push({ id: "push", label: "push", shortcut: "s" });
     }
 
-    if (state.hasValidRemote && !state.pr && state.commits.length > 0) {
+    if (isSetUp && state.hasValidRemote && !state.pr && state.commits.length > 0) {
       actions.push({ id: "pr", label: "pr", shortcut: "p" });
     }
 
-    if (state.issue && state.pr?.state !== "merged") {
+    if (isSetUp && state.issue && state.pr?.state !== "merged") {
       actions.push({ id: "run", label: "run", shortcut: "r" });
     }
   }
 
   // Common navigation/config actions
-  if (state.hasValidRemote) {
+  if (isSetUp && state.hasValidRemote) {
     actions.push({ id: "list", label: "list", shortcut: "l" });
-  } else {
+  } else if (!state.hasValidRemote) {
     actions.push({ id: "github-remote", label: "github", shortcut: "g" });
   }
   actions.push({ id: "refresh", label: "refresh", shortcut: "f" });

--- a/src/tui/display.test.ts
+++ b/src/tui/display.test.ts
@@ -52,6 +52,7 @@ const mockBaseState: TuiState = {
   hasUIChanges: false,
   isPlaywrightAvailable: false,
   hasValidRemote: true,
+  hasLabels: true,
 };
 
 const mockActions: TuiAction[] = [
@@ -276,6 +277,59 @@ describe("display", () => {
       expect(output).not.toContain(
         "Press [g] to create a GitHub repo and push"
       );
+    });
+
+    it("renders setup banner when not initialized", () => {
+      const state: TuiState = {
+        ...mockBaseState,
+        branch: "main",
+        isOnMain: true,
+        hasConfig: false,
+        hasLabels: false,
+      };
+
+      const lines = buildDashboardLines(state, mockActions).map(stripAnsi);
+      const output = lines.join("\n");
+
+      expect(output).toContain("Setup");
+      expect(output).toContain('Run "gent init" to set up this repository');
+      expect(output).toContain("Press [i] to initialize");
+    });
+
+    it("renders setup banner when labels are missing", () => {
+      const state: TuiState = {
+        ...mockBaseState,
+        branch: "main",
+        isOnMain: true,
+        hasConfig: true,
+        hasLabels: false,
+        hasValidRemote: true,
+      };
+
+      const lines = buildDashboardLines(state, mockActions).map(stripAnsi);
+      const output = lines.join("\n");
+
+      expect(output).toContain("Setup");
+      expect(output).toContain('Run "gent setup-labels" to create required GitHub labels');
+      expect(output).toContain("Press [b] to set up labels");
+    });
+
+    it("does not render setup banner when fully initialized", () => {
+      const state: TuiState = {
+        ...mockBaseState,
+        branch: "main",
+        isOnMain: true,
+        hasConfig: true,
+        hasLabels: true,
+        hasValidRemote: true,
+      };
+
+      const lines = buildDashboardLines(state, mockActions).map(stripAnsi);
+      const output = lines.join("\n");
+
+      expect(output).not.toContain("Setup");
+      expect(output).not.toContain("gent init");
+      expect(output).not.toContain("gent setup-labels");
     });
 
     it("renders bullets for list items", () => {

--- a/src/tui/display.ts
+++ b/src/tui/display.ts
@@ -384,8 +384,16 @@ export function buildDashboardLines(
     }
   }
 
-  // Hint
-  if (!state.hasValidRemote) {
+  // Setup hints (take priority over other hints)
+  if (!state.hasConfig) {
+    section("Setup");
+    out(row(chalk.yellow('Run "gent init" to set up this repository'), w));
+    out(row(chalk.dim("Press [i] to initialize"), w));
+  } else if (state.hasValidRemote && !state.hasLabels) {
+    section("Setup");
+    out(row(chalk.yellow('Run "gent setup-labels" to create required GitHub labels'), w));
+    out(row(chalk.dim("Press [b] to set up labels"), w));
+  } else if (!state.hasValidRemote) {
     section("Hint");
     out(
       row(

--- a/src/utils/validators.test.ts
+++ b/src/utils/validators.test.ts
@@ -5,9 +5,13 @@ import {
   sanitizeSlug,
   checkCodexCLI,
   checkAIProvider,
+  checkInitialized,
 } from "./validators.js";
 
 vi.mock("execa");
+vi.mock("../lib/config.js", () => ({
+  configExists: vi.fn(),
+}));
 
 describe("validators", () => {
   describe("isValidIssueNumber", () => {
@@ -61,6 +65,20 @@ describe("validators", () => {
       vi.mocked(execa).mockRejectedValue(new Error("Command not found"));
       const result = await checkCodexCLI();
       expect(result).toBe(false);
+    });
+  });
+
+  describe("checkInitialized", () => {
+    it("should return true when .gent.yml exists", async () => {
+      const { configExists } = await import("../lib/config.js");
+      vi.mocked(configExists).mockReturnValue(true);
+      expect(checkInitialized()).toBe(true);
+    });
+
+    it("should return false when .gent.yml is absent", async () => {
+      const { configExists } = await import("../lib/config.js");
+      vi.mocked(configExists).mockReturnValue(false);
+      expect(checkInitialized()).toBe(false);
     });
   });
 

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -1,5 +1,6 @@
 import { execa } from "execa";
 import type { GentConfig, AIProvider } from "../types/index.js";
+import { configExists } from "../lib/config.js";
 
 export async function checkGhCli(): Promise<boolean> {
   try {
@@ -121,6 +122,10 @@ export async function validatePrerequisites(config?: GentConfig): Promise<{
     valid: missing.length === 0,
     missing,
   };
+}
+
+export function checkInitialized(cwd?: string): boolean {
+  return configExists(cwd);
 }
 
 export function isValidIssueNumber(value: string): boolean {


### PR DESCRIPTION
## Summary
- Add prerequisite checks (`checkInitialized` and `checkLabelsExist`) that detect missing `.gent.yml` or GitHub labels and show actionable hints instead of failing silently
- Guard CLI commands (`create`, `run`, `list`, `pr`, `fix`, `status`) with init/label validators that display clear setup instructions when prerequisites aren't met
- Update TUI dashboard to track `isInitialized`/`hasLabels` state, hide unavailable actions, show setup actions (`init`/`setup-labels`), and display a prominent setup status banner

## Test Plan
- [ ] Run `gent create "test"` on a repo without `.gent.yml` — verify hint to run `gent init` is shown
- [ ] Run `gent create "test"` on an initialized repo without labels — verify hint to run `gent setup-labels` is shown
- [ ] Launch `gent` TUI on an uninitialized repo — verify only `init` and `quit` actions are visible
- [ ] Launch `gent` TUI on an initialized repo without labels — verify `setup-labels` action is shown and label-dependent actions are hidden
- [ ] Launch `gent` TUI on a fully set up repo — verify all actions are available and no banners are shown
- [ ] Run unit tests: `npm test` — verify all new tests in `validators.test.ts`, `github.test.ts`, `state.test.ts`, `actions.test.ts`, and `display.test.ts` pass

Closes #89


---
*Created with Claude by [gent](https://github.com/Rotorsoft/gent)*