### PR TITLE
Configure semantic-release to trigger patch releases for refactor commits

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,7 +1,15 @@
 {
   "branches": ["main"],
   "plugins": [
-    "@semantic-release/commit-analyzer",
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "releaseRules": [
+          { "type": "refactor", "release": "patch" },
+          { "type": "perf", "release": "patch" }
+        ]
+      }
+    ],
     "@semantic-release/release-notes-generator",
     "@semantic-release/changelog",
     "@semantic-release/npm",

--- a/progress.txt
+++ b/progress.txt
@@ -298,3 +298,8 @@ Each entry documents: date, feature, decisions, files changed, tests, and concer
 - Files: src/commands/status.ts, progress.txt
 - Changes: Replaced all loose `logger.info/success/warning/error` calls in status command with `logger.table()` bordered tables for Configuration, AI Provider, Prerequisites, Git Status, Linked Issue, and Pull Request sections. Imported `checkCodexCLI` and added Codex CLI availability check. Updated `getProviderStatus` to accept all `AIProvider` types. Parallelized prerequisite checks with `Promise.all`. Suggested Actions section kept as `logger.list()`.
 - Decisions: Used chalk coloring in table values to preserve semantic status (green=ok, red=error, yellow=warning) that was previously conveyed by logger icons. Feedback items rendered as empty-key table entries for alignment within the PR table. Suggested Actions also converted to table with command keys and description values. Also converted `logger.box()` calls in pr.ts, create.ts, init.ts, and run.ts to `logger.table()` for consistent bordered table output across all commands.
+
+[2026-02-06] #110 fix: configure semantic-release to trigger patch releases for refactor and perf commits
+- Files: .releaserc.json
+- Changes: Added custom `releaseRules` to `@semantic-release/commit-analyzer` mapping `refactor` and `perf` commit types to `patch` releases.
+- Decisions: Configuration-only change. Existing `feat` (minor) and `fix` (patch) defaults are preserved since custom rules extend (not replace) defaults.


### PR DESCRIPTION
## Summary
- Configure `@semantic-release/commit-analyzer` with custom `releaseRules` in `.releaserc.json` to trigger patch releases for `refactor` and `perf` commit types
- Previously only `feat` (minor) and `fix` (patch) commits triggered releases, causing refactor commits like the recent status command table conversions to be unreleased
- Existing `feat` and `fix` release behavior is preserved unchanged

## Test Plan
- [ ] Run `pnpm exec semantic-release --dry-run` to validate the updated configuration
- [ ] After merging, confirm the release workflow triggers a new patch version that includes the previously unreleased refactor commits
- [ ] Verify `feat` commits still trigger minor releases and `fix` commits still trigger patch releases

Closes #110


---
*Created with Claude by [gent](https://github.com/Rotorsoft/gent)*