### PR TITLE
Support copy and paste in the multi-line input dialog

### DIFF
--- a/progress.txt
+++ b/progress.txt
@@ -303,3 +303,8 @@ Each entry documents: date, feature, decisions, files changed, tests, and concer
 - Files: .releaserc.json
 - Changes: Added custom `releaseRules` to `@semantic-release/commit-analyzer` mapping `refactor` and `perf` commit types to `patch` releases.
 - Decisions: Configuration-only change. Existing `feat` (minor) and `fix` (patch) defaults are preserved since custom rules extend (not replace) defaults.
+
+[2026-02-08] #112 feat: support copy and paste in multi-line and single-line input dialogs
+- Files: src/tui/key-reader.ts, src/tui/multiline-input.ts, src/tui/input-dialog.ts, src/tui/key-reader.test.ts, src/tui/multiline-input.test.ts
+- Changes: Enabled bracketed paste mode in readKey() with \x1b[?2004h/l escape codes. Added detection for bracketed paste delimiters and non-bracketed paste fallback for multi-char data. Added "paste" case to multiline input (preserves newlines) and single-line input (strips newlines). Added 12 key-reader tests and 5 paste rendering tests.
+- Decisions: Guard non-bracketed paste with !data.startsWith("\x1b") to avoid misidentifying unknown escape sequences. Normalize \r\n to \n in both paste paths.

--- a/src/tui/input-dialog.ts
+++ b/src/tui/input-dialog.ts
@@ -62,6 +62,16 @@ export async function showInput(opts: InputOptions): Promise<string | null> {
         render();
         break;
 
+      case "paste": {
+        const flat = key.raw.replace(/\n/g, "");
+        if (flat.length > 0) {
+          value += flat;
+          cursorBlink = true;
+          render();
+        }
+        break;
+      }
+
       default:
         // Single printable character
         if (key.raw.length === 1 && key.raw.charCodeAt(0) >= 32) {

--- a/src/tui/key-reader.test.ts
+++ b/src/tui/key-reader.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { EventEmitter } from "events";
+import { readKey } from "./key-reader.js";
+
+describe("readKey", () => {
+  const realStdin = process.stdin;
+  let mockStdin: EventEmitter & {
+    isRaw: boolean;
+    setRawMode: ReturnType<typeof vi.fn>;
+    resume: ReturnType<typeof vi.fn>;
+    pause: ReturnType<typeof vi.fn>;
+    setEncoding: ReturnType<typeof vi.fn>;
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let writeSpy: any;
+
+  beforeEach(() => {
+    mockStdin = Object.assign(new EventEmitter(), {
+      isRaw: false,
+      setRawMode: vi.fn(),
+      resume: vi.fn(),
+      pause: vi.fn(),
+      setEncoding: vi.fn(),
+    });
+    Object.defineProperty(process, "stdin", {
+      value: mockStdin,
+      configurable: true,
+      writable: true,
+    });
+    writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, "stdin", {
+      value: realStdin,
+      configurable: true,
+      writable: true,
+    });
+    writeSpy.mockRestore();
+  });
+
+  it("handles bracketed paste", async () => {
+    const p = readKey();
+    mockStdin.emit("data", "\x1b[200~hello world\x1b[201~");
+    const key = await p;
+    expect(key).toEqual({ name: "paste", raw: "hello world" });
+  });
+
+  it("handles bracketed paste with newlines", async () => {
+    const p = readKey();
+    mockStdin.emit("data", "\x1b[200~line1\nline2\nline3\x1b[201~");
+    const key = await p;
+    expect(key).toEqual({ name: "paste", raw: "line1\nline2\nline3" });
+  });
+
+  it("normalizes \\r\\n to \\n in bracketed paste", async () => {
+    const p = readKey();
+    mockStdin.emit("data", "\x1b[200~line1\r\nline2\x1b[201~");
+    const key = await p;
+    expect(key).toEqual({ name: "paste", raw: "line1\nline2" });
+  });
+
+  it("handles bracketed paste without end marker", async () => {
+    const p = readKey();
+    mockStdin.emit("data", "\x1b[200~partial paste");
+    const key = await p;
+    expect(key).toEqual({ name: "paste", raw: "partial paste" });
+  });
+
+  it("handles non-bracketed paste (multi-char data)", async () => {
+    const p = readKey();
+    mockStdin.emit("data", "hello world");
+    const key = await p;
+    expect(key).toEqual({ name: "paste", raw: "hello world" });
+  });
+
+  it("filters non-printable characters from non-bracketed paste", async () => {
+    const p = readKey();
+    mockStdin.emit("data", "hello\x01world");
+    const key = await p;
+    expect(key).toEqual({ name: "paste", raw: "helloworld" });
+  });
+
+  it("preserves newlines in non-bracketed paste", async () => {
+    const p = readKey();
+    mockStdin.emit("data", "line1\nline2");
+    const key = await p;
+    expect(key).toEqual({ name: "paste", raw: "line1\nline2" });
+  });
+
+  it("still handles single printable characters", async () => {
+    const p = readKey();
+    mockStdin.emit("data", "a");
+    const key = await p;
+    expect(key).toEqual({ name: "a", raw: "a" });
+  });
+
+  it("still handles escape sequences", async () => {
+    const p = readKey();
+    mockStdin.emit("data", "\x1b[A");
+    const key = await p;
+    expect(key).toEqual({ name: "up", raw: "\x1b[A" });
+  });
+
+  it("enables bracketed paste mode on entry", async () => {
+    const p = readKey();
+    mockStdin.emit("data", "a");
+    await p;
+    expect(writeSpy).toHaveBeenCalledWith("\x1b[?2004h");
+  });
+
+  it("disables bracketed paste mode on resolve", async () => {
+    const p = readKey();
+    mockStdin.emit("data", "a");
+    await p;
+    expect(writeSpy).toHaveBeenCalledWith("\x1b[?2004l");
+  });
+
+  it("retries on unknown escape sequences", async () => {
+    const p = readKey();
+    // First emit an unknown escape sequence (should be retried)
+    mockStdin.emit("data", "\x1b[?999h");
+    // Then emit a real key
+    mockStdin.emit("data", "x");
+    const key = await p;
+    expect(key).toEqual({ name: "x", raw: "x" });
+  });
+});

--- a/src/tui/multiline-input.test.ts
+++ b/src/tui/multiline-input.test.ts
@@ -193,6 +193,45 @@ describe("moveCursorWordRight", () => {
   });
 });
 
+describe("paste insertion rendering", () => {
+  it("renders correctly after pasting text at beginning", () => {
+    // Simulate: value="" cursor=0, paste "hello" -> value="hello" cursor=5
+    const lines = buildMultilineInputContent("Label:", "hello", true, 40, 5);
+    expect(stripAnsi(lines[2])).toContain("hello");
+  });
+
+  it("renders correctly after pasting text in middle", () => {
+    // Simulate: value="ab" cursor=1, paste "XY" -> value="aXYb" cursor=3
+    const lines = buildMultilineInputContent("Label:", "aXYb", true, 40, 3);
+    expect(stripAnsi(lines[2])).toContain("aXYb");
+  });
+
+  it("renders correctly after pasting multi-line text", () => {
+    // Simulate: value="ab" cursor=1, paste "X\nY" -> value="aX\nYb" cursor=4
+    const lines = buildMultilineInputContent("Label:", "aX\nYb", true, 40, 4);
+    expect(stripAnsi(lines[2])).toContain("aX");
+    expect(stripAnsi(lines[3])).toContain("Yb");
+    // label + blank + 2 input lines = 4
+    expect(lines.length).toBe(4);
+  });
+
+  it("renders correctly after pasting at end of text", () => {
+    // Simulate: value="hello" cursor=5, paste " world" -> value="hello world" cursor=11
+    const lines = buildMultilineInputContent("Label:", "hello world", true, 40, 11);
+    expect(stripAnsi(lines[2])).toContain("hello world");
+  });
+
+  it("advances cursor correctly for multi-line paste", () => {
+    // Simulate: value="" cursor=0, paste "a\nb\nc" -> cursor at 5 (end)
+    const value = "a\nb\nc";
+    const cursorPos = value.length; // 5
+    const visualLines = getVisualLines(value, 38);
+    const { row, col } = findCursorVisualPos(visualLines, cursorPos);
+    expect(row).toBe(2); // third visual line
+    expect(col).toBe(1); // after "c"
+  });
+});
+
 describe("buildMultilineInputContent with cursorPos", () => {
   it("does not insert extra characters at cursor position", () => {
     const lines = buildMultilineInputContent("Label:", "hello", true, 40, 2);

--- a/src/tui/multiline-input.ts
+++ b/src/tui/multiline-input.ts
@@ -275,6 +275,13 @@ export async function showMultilineInput(
         render();
         break;
 
+      case "paste":
+        value = value.slice(0, cursorPos) + key.raw + value.slice(cursorPos);
+        cursorPos += key.raw.length;
+        cursorBlink = true;
+        render();
+        break;
+
       default:
         if (key.raw.length === 1 && key.raw.charCodeAt(0) >= 32) {
           value = value.slice(0, cursorPos) + key.raw + value.slice(cursorPos);


### PR DESCRIPTION
## Summary
- Add paste support (both bracketed and non-bracketed) to the custom key reader by detecting `\x1b[200~...\x1b[201~` delimiters and multi-character data chunks, resolving them as `paste` key events
- Handle `paste` key events in the multi-line input dialog (preserving newlines) and single-line input dialog (stripping newlines), inserting full clipboard content at the cursor position
- Add unit tests for key reader paste detection and multi-line input paste insertion logic

## Test Plan
- [ ] Run `npm test` to verify all new and existing unit tests pass
- [ ] In the TUI dashboard, press `n` to open "New Ticket" and paste multi-line text — verify it appears correctly with preserved newlines and proper word wrapping
- [ ] Paste text at the beginning, middle, and end of existing content in the multi-line input — verify correct cursor positioning
- [ ] Paste text into a single-line input dialog — verify newlines are stripped and text is inserted inline
- [ ] Verify normal keyboard input (typing, arrow keys, Ctrl+S, Esc) continues to work unchanged after the changes

Closes #112


---
*Created with Claude by [gent](https://github.com/Rotorsoft/gent)*