### PR TITLE
Add status badges to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # @rotorsoft/gent
 
+[![CI](https://github.com/Rotorsoft/gent/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/Rotorsoft/gent/actions/workflows/ci.yml) [![Release](https://github.com/Rotorsoft/gent/actions/workflows/release.yml/badge.svg?branch=main)](https://github.com/Rotorsoft/gent/actions/workflows/release.yml) [![npm version](https://img.shields.io/npm/v/@rotorsoft/gent)](https://www.npmjs.com/package/@rotorsoft/gent) [![npm downloads](https://img.shields.io/npm/dm/@rotorsoft/gent)](https://www.npmjs.com/package/@rotorsoft/gent) [![License](https://img.shields.io/npm/l/@rotorsoft/gent)](https://github.com/Rotorsoft/gent/blob/main/LICENSE) [![Node.js](https://img.shields.io/node/v/@rotorsoft/gent)](https://nodejs.org)
+
 AI-powered GitHub workflow tool - leverage AI (Claude, Gemini, or Codex) to create tickets, implement features, and manage PRs from an interactive dashboard.
 
 

--- a/progress.txt
+++ b/progress.txt
@@ -308,3 +308,8 @@ Each entry documents: date, feature, decisions, files changed, tests, and concer
 - Files: src/tui/key-reader.ts, src/tui/multiline-input.ts, src/tui/input-dialog.ts, src/tui/key-reader.test.ts, src/tui/multiline-input.test.ts
 - Changes: Enabled bracketed paste mode in readKey() with \x1b[?2004h/l escape codes. Added detection for bracketed paste delimiters and non-bracketed paste fallback for multi-char data. Added "paste" case to multiline input (preserves newlines) and single-line input (strips newlines). Added 12 key-reader tests and 5 paste rendering tests.
 - Decisions: Guard non-bracketed paste with !data.startsWith("\x1b") to avoid misidentifying unknown escape sequences. Normalize \r\n to \n in both paste paths.
+
+[2026-02-08] #113 docs: add status badges to README.md
+- Files: README.md, progress.txt
+- Changes: Added six badges (CI, Release, npm version, npm downloads, License, Node.js) below the title and above the description, each linking to its corresponding resource.
+- Decisions: Used standard shields.io and GitHub Actions badge URLs. Single badge row with space separators.


### PR DESCRIPTION
## Summary
- Added six status badges (CI, Release, npm version, npm downloads, License, Node.js) to the top of README.md, placed between the title and description
- Badges provide at-a-glance project health indicators for contributors and users, linking to their respective resources (GitHub Actions workflows, npm package page, license)

## Test Plan
- [ ] Open the README on the GitHub PR branch and confirm all six badges render correctly
- [ ] Verify each badge links to the correct target (CI workflow, Release workflow, npm package page, LICENSE)
- [ ] Confirm no other README content was modified

Closes #113


---
*Created with Claude by [gent](https://github.com/Rotorsoft/gent)*